### PR TITLE
iconの取得を減らす

### DIFF
--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -182,6 +182,12 @@ func postIconHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get last inserted icon id: "+err.Error())
 	}
 
+	userModel := UserModel{}
+	if err = tx.GetContext(ctx, &userModel, "SELECT * FROM users WHERE id = ?", userID); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get user: "+err.Error())
+	}
+	addIconHashByUsername(userModel.Name, fmt.Sprintf("%x", sha256.Sum256(req.Image)))
+
 	if err := tx.Commit(); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
 	}


### PR DESCRIPTION
refs #1 

下記クエリがslow queryが疑問の起点。

```
# Query 2: 947.26 QPS, 0.32x concurrency, ID 0x84B457C910C4A79FC9EBECB8B1065C66 at byte 164917109
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-06-29T05:45:47 to 2024-06-29T05:47:05
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         16   73886
# Exec time     12     25s    57us    66ms   337us   596us     1ms   176us
# Lock time      7    97ms       0     3ms     1us     1us    18us     1us
# Rows sent      9  66.68k       0       1    0.92    0.99    0.26    0.99
# Rows examine   0  66.68k       0       1    0.92    0.99    0.26    0.99
# Query size     2   3.10M      41      44   43.94   42.48    0.16   42.48
# String:
# Databases    isupipe
# Hosts        ip-192-168-0-11.ap-northeast-1.compute.inter...
# Users        isucon
# Query_time distribution
#   1us
#  10us  ##
# 100us  ################################################################
#   1ms  ##
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'icons'\G
#    SHOW CREATE TABLE `isupipe`.`icons`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT image FROM icons WHERE user_id = 1082\G
```

 `fillUserResponse()` ではicon hashしか要らないはずなので、hashのcacheにhitしたらdb問い合わせをしないようにする。