### PR TITLE
ユーザをメモリに持つ

### DIFF
--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -397,8 +397,8 @@ func moderateHandler(c echo.Context) error {
 }
 
 func fillLivecommentResponse(ctx context.Context, tx *sqlx.Tx, livecommentModel LivecommentModel) (Livecomment, error) {
-	commentOwnerModel := UserModel{}
-	if err := tx.GetContext(ctx, &commentOwnerModel, "SELECT * FROM users WHERE id = ?", livecommentModel.UserID); err != nil {
+	commentOwnerModel, err := getUserById(livecommentModel.UserID)
+	if err != nil {
 		return Livecomment{}, err
 	}
 	commentOwner, err := fillUserResponse(ctx, tx, commentOwnerModel)
@@ -428,8 +428,8 @@ func fillLivecommentResponse(ctx context.Context, tx *sqlx.Tx, livecommentModel 
 }
 
 func fillLivecommentReportResponse(ctx context.Context, tx *sqlx.Tx, reportModel LivecommentReportModel) (LivecommentReport, error) {
-	reporterModel := UserModel{}
-	if err := tx.GetContext(ctx, &reporterModel, "SELECT * FROM users WHERE id = ?", reportModel.UserID); err != nil {
+	reporterModel, err := getUserById(reportModel.UserID)
+	if err != nil {
 		return LivecommentReport{}, err
 	}
 	reporter, err := fillUserResponse(ctx, tx, reporterModel)

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -485,8 +485,8 @@ func getLivecommentReportsHandler(c echo.Context) error {
 }
 
 func fillLivestreamResponse(ctx context.Context, tx *sqlx.Tx, livestreamModel LivestreamModel) (Livestream, error) {
-	ownerModel := UserModel{}
-	if err := tx.GetContext(ctx, &ownerModel, "SELECT * FROM users WHERE id = ?", livestreamModel.UserID); err != nil {
+	ownerModel, err := getUserById(livestreamModel.UserID)
+	if err != nil {
 		return Livestream{}, err
 	}
 	owner, err := fillUserResponse(ctx, tx, ownerModel)

--- a/go/reaction_handler.go
+++ b/go/reaction_handler.go
@@ -142,8 +142,8 @@ func postReactionHandler(c echo.Context) error {
 }
 
 func fillReactionResponse(ctx context.Context, tx *sqlx.Tx, reactionModel ReactionModel) (Reaction, error) {
-	userModel := UserModel{}
-	if err := tx.GetContext(ctx, &userModel, "SELECT * FROM users WHERE id = ?", reactionModel.UserID); err != nil {
+	userModel, err := getUserById(reactionModel.UserID)
+	if err != nil {
 		return Reaction{}, err
 	}
 	user, err := fillUserResponse(ctx, tx, userModel)


### PR DESCRIPTION
refs #1 

```
# Query 3: 1.88k QPS, 0.25x concurrency, ID 0xEA1E6309EEEFF9A6831AD2FB940FC23C at byte 113247500
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-06-29T07:20:47 to 2024-06-29T07:22:00
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         22  137278
# Exec time     12     18s    50us    38ms   133us   247us   456us    84us
# Lock time     10   177ms       0     9ms     1us     1us    28us     1us
# Rows sent     11 134.06k       1       1       1       1       0       1
# Rows examine   1 134.06k       1       1       1       1       0       1
# Query size     3   4.58M      32      35   34.97   34.95    0.33   34.95
# String:
# Databases    isupipe
# Hosts        ip-192-168-0-11.ap-northeast-1.compute.inter...
# Users        isucon
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ###################
#   1ms  #
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM users WHERE id = 1143\G
```