### PR TITLE
iconsテーブルへのdeadlockを解消

### DIFF
--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -162,17 +162,7 @@ func postIconHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "failed to decode the request body as json")
 	}
 
-	tx, err := dbConn.BeginTxx(ctx, nil)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to begin transaction: "+err.Error())
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, "DELETE FROM icons WHERE user_id = ?", userID); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old user icon: "+err.Error())
-	}
-
-	rs, err := tx.ExecContext(ctx, "INSERT INTO icons (user_id, image) VALUES (?, ?)", userID, req.Image)
+	rs, err := dbConn.ExecContext(ctx, "REPLACE INTO icons (user_id, image) VALUES (?, ?)", userID, req.Image)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert new user icon: "+err.Error())
 	}
@@ -187,10 +177,6 @@ func postIconHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get user: "+err.Error())
 	}
 	addIconHashByUsername(userModel.Name, fmt.Sprintf("%x", sha256.Sum256(req.Image)))
-
-	if err := tx.Commit(); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
-	}
 
 	return c.JSON(http.StatusCreated, &PostIconResponse{
 		ID: iconID,

--- a/sql/initdb.d/10_schema.sql
+++ b/sql/initdb.d/10_schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE `icons` (
   `user_id` BIGINT NOT NULL,
   `image` LONGBLOB NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-create index icons_user_id_index on icons (user_id);
+create unique index icons_user_id_index on icons (user_id);
 
 -- ユーザごとのカスタムテーマ
 CREATE TABLE `themes` (


### PR DESCRIPTION
refs #20 

iconsテーブルへのinsertでdeadlockが起きていた

before

```
 Count    Total     Mean   Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max    2xx     3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
  3920   62.442   0.0159   0.0154   0.004   0.011   0.032   0.048   0.077   0.219   3722       0    0  198       71027          9         18        149  POST /api/icon HTTP/1.1
```

5xx 198回

log

```
TRANSACTION 804835, ACTIVE 0 sec inserting
mysql tables in use 1, locked 1
LOCK WAIT 3 lock struct(s), heap size 1128, 2 row lock(s), undo log entries 1
MySQL thread id 18, OS thread handle 123250503829056, query id 36111 ip-192-168-0-11.ap-northeast-1.compute.internal 192.168.0.11 isucon update
INSERT INTO icons (user_id, image) VALUES (1012, _binary'
RECORD LOCKS space id 1102 page no 5 n bits 72 index icons_user_id_index of table `isupipe`.`icons` trx id 804835 lock_mode X
Record lock, heap no 1 PHYSICAL RECORD: n_fields 1; compact format; info bits 0
 0: len 8; hex 73757072656d756d; asc supremum;;

RECORD LOCKS space id 1102 page no 5 n bits 72 index icons_user_id_index of table `isupipe`.`icons` trx id 804835 lock_mode X insert intention waiting
Record lock, heap no 1 PHYSICAL RECORD: n_fields 1; compact format; info bits 0
 0: len 8; hex 73757072656d756d; asc supremum;;
```

after
```
 Count    Total     Mean   Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max    2xx     3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
 1219   11.952   0.0098   0.0062   0.003   0.008   0.016   0.021   0.035   0.066  1219      0    0    0       13521          9         11         12  POST /api/icon HTTP/1.1
 ```

5xx 0回 🎉 