### PR TITLE
ErrNoRowsエラーのハンドリング

### DIFF
--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -495,6 +495,9 @@ func getLivecommentReportsHandler(c echo.Context) error {
 	reports := make([]LivecommentReport, len(reportModels))
 	for i := range reportModels {
 		report, err := fillLivecommentReportResponse(ctx, tx, *reportModels[i])
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to fill livecomment report: "+err.Error())
 		}


### PR DESCRIPTION
refs #20

ErrNoRowsエラーがちゃんとハンドリング出来てないエラーが出ているので治す

> Aug 11 01:48:41 ip-192-168-0-11 isupipe[23519]: {"time":"2024-08-11T01:48:41.512419485Z","id":"","remote_ip":"127.0.0.1","host":"satomigoto0.t.isucon.pw","method":"GET","uri":"/api/livestream/7528/report","user_agent":"isucandar","status":500,"error":"code=500, message=failed to fill livecomment report: sql: no rows in result set","latency":5907682,"latency_human":"5.907682ms","bytes_in":0,"bytes_out":92}