### PR TITLE
NGワード判定をアプリ側で判断する

### DIFF
--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -202,21 +203,9 @@ func postLivecommentHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get NG words: "+err.Error())
 	}
 
-	var hitSpam int
 	for _, ngword := range ngwords {
-		query := `
-		SELECT COUNT(*)
-		FROM
-		(SELECT ? AS text) AS texts
-		INNER JOIN
-		(SELECT CONCAT('%', ?, '%')	AS pattern) AS patterns
-		ON texts.text LIKE patterns.pattern;
-		`
-		if err := tx.GetContext(ctx, &hitSpam, query, req.Comment, ngword.Word); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get hitspam: "+err.Error())
-		}
-		c.Logger().Infof("[hitSpam=%d] comment = %s", hitSpam, req.Comment)
-		if hitSpam >= 1 {
+		if strings.Contains(req.Comment, ngword.Word) {
+			c.Logger().Infof("[hitSpam=%d] comment = %s", hitSpam, req.Comment)
 			return echo.NewHTTPError(http.StatusBadRequest, "このコメントがスパム判定されました")
 		}
 	}

--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -205,7 +205,7 @@ func postLivecommentHandler(c echo.Context) error {
 
 	for _, ngword := range ngwords {
 		if strings.Contains(req.Comment, ngword.Word) {
-			c.Logger().Infof("[hitSpam=%d] comment = %s", hitSpam, req.Comment)
+			c.Logger().Infof("[hitSpam] comment = %s", req.Comment)
 			return echo.NewHTTPError(http.StatusBadRequest, "このコメントがスパム判定されました")
 		}
 	}


### PR DESCRIPTION
refs #20 

コメント中にNGワードが含まれているかどうかの判定でDBを使う必要がないのでアプリ側でやる。

before
https://isunarabe.org/teams/671/benchmark_jobs/11132

after
https://isunarabe.org/teams/671/benchmark_jobs/11135